### PR TITLE
장르 / 위시리스트 구현하기

### DIFF
--- a/src/main/java/com/ticketland/ticketland/global/exception/NotFoundException.java
+++ b/src/main/java/com/ticketland/ticketland/global/exception/NotFoundException.java
@@ -5,7 +5,7 @@ import com.ticketland.ticketland.global.exception.core.ErrorCode;
 
 public class NotFoundException extends CustomException {
 
-    public NotFoundException(String message) {
-        super(message, ErrorCode.NOT_FOUND);
+    public NotFoundException(String notFoundResource) {
+        super(ErrorCode.NOT_FOUND.getMsg().formatted(notFoundResource), ErrorCode.NOT_FOUND);
     }
 }

--- a/src/main/java/com/ticketland/ticketland/global/exception/core/ErrorCode.java
+++ b/src/main/java/com/ticketland/ticketland/global/exception/core/ErrorCode.java
@@ -15,7 +15,7 @@ public enum ErrorCode {
 
     EMAIL_NOT_VERIFIED(400, "이메일 인증이 되어있지 않습니다."),
 
-    NOT_FOUND(404, "해당 리소스를 찾을 수 없습니다."),
+    NOT_FOUND(404, "해당 %s을 찾을 수 없습니다."),
 
     ACCESS_DENIED(403, "권한이 부족합니다.")
     ;

--- a/src/main/java/com/ticketland/ticketland/show/domain/Genre.java
+++ b/src/main/java/com/ticketland/ticketland/show/domain/Genre.java
@@ -1,0 +1,18 @@
+package com.ticketland.ticketland.show.domain;
+
+import com.ticketland.ticketland.global.domain.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Genre extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String genreName;
+}

--- a/src/main/java/com/ticketland/ticketland/show/domain/Show.java
+++ b/src/main/java/com/ticketland/ticketland/show/domain/Show.java
@@ -2,9 +2,12 @@ package com.ticketland.ticketland.show.domain;
 
 import com.ticketland.ticketland.global.domain.BaseTimeEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 
@@ -18,6 +21,11 @@ public class Show extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "genre_id")
+    private Genre genre;
+
     private String performer;
     private String title;
     private String descriptionImage;
@@ -25,4 +33,8 @@ public class Show extends BaseTimeEntity {
     private LocalDateTime startTime;
     private Integer duration; // 공연시간 (분)
     private boolean isDeleted;
+
+    public String getGenreName() {
+        return genre.getGenreName();
+    }
 }

--- a/src/main/java/com/ticketland/ticketland/show/dto/ShowSearchCondition.java
+++ b/src/main/java/com/ticketland/ticketland/show/dto/ShowSearchCondition.java
@@ -13,6 +13,7 @@ import lombok.ToString;
 @ToString
 @Setter
 public class ShowSearchCondition {
+    private String genre;
     private String title;
     private String performer;
     private ShowStatus showStatus;

--- a/src/main/java/com/ticketland/ticketland/show/dto/ShowSingleResponse.java
+++ b/src/main/java/com/ticketland/ticketland/show/dto/ShowSingleResponse.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 @Builder
 public class ShowSingleResponse {
     private Long id;
+    private String genre;
     private String performer;
     private String title;
     private String descriptionImage;
@@ -24,6 +25,7 @@ public class ShowSingleResponse {
     public static ShowSingleResponse from(Show show) {
         return ShowSingleResponse.builder()
                 .id(show.getId())
+                .genre(show.getGenreName())
                 .performer(show.getPerformer())
                 .title(show.getTitle())
                 .descriptionImage(show.getDescriptionImage())

--- a/src/main/java/com/ticketland/ticketland/show/service/ShowService.java
+++ b/src/main/java/com/ticketland/ticketland/show/service/ShowService.java
@@ -18,7 +18,7 @@ public class ShowService {
 
     public ShowSingleResponse findById(Long showId) {
         Show show = showRepository.findById(showId)
-                .orElseThrow(() -> new NotFoundException("해당 공연을 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException("공연"));
 
         return ShowSingleResponse.from(show);
     }

--- a/src/main/java/com/ticketland/ticketland/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/ticketland/ticketland/wishlist/controller/WishlistController.java
@@ -1,0 +1,27 @@
+package com.ticketland.ticketland.wishlist.controller;
+
+import com.ticketland.ticketland.user.constant.UserRole;
+import com.ticketland.ticketland.wishlist.dto.WishlistResponse;
+import com.ticketland.ticketland.wishlist.service.WishlistService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/wishlist")
+@RequiredArgsConstructor
+public class WishlistController {
+
+    private final WishlistService wishlistService;
+
+    @Secured(UserRole.Authority.USER)
+    @PostMapping("/{showId}")
+    public ResponseEntity<WishlistResponse> createWishlist(@AuthenticationPrincipal Long userId, @PathVariable Long showId) {
+        return ResponseEntity.ok(wishlistService.createWishlist(userId, showId));
+    }
+}

--- a/src/main/java/com/ticketland/ticketland/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/ticketland/ticketland/wishlist/controller/WishlistController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,5 +24,12 @@ public class WishlistController {
     @PostMapping("/{showId}")
     public ResponseEntity<WishlistResponse> createWishlist(@AuthenticationPrincipal Long userId, @PathVariable Long showId) {
         return ResponseEntity.ok(wishlistService.createWishlist(userId, showId));
+    }
+
+    @Secured(UserRole.Authority.USER)
+    @DeleteMapping("/{wishlistId}")
+    public ResponseEntity<?> deleteWishlist(@PathVariable Long wishlistId) {
+        wishlistService.deleteWishlist(wishlistId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/ticketland/ticketland/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/ticketland/ticketland/wishlist/controller/WishlistController.java
@@ -1,13 +1,16 @@
 package com.ticketland.ticketland.wishlist.controller;
 
 import com.ticketland.ticketland.user.constant.UserRole;
+import com.ticketland.ticketland.wishlist.dto.WishlistPageResponse;
 import com.ticketland.ticketland.wishlist.dto.WishlistResponse;
 import com.ticketland.ticketland.wishlist.service.WishlistService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,5 +34,11 @@ public class WishlistController {
     public ResponseEntity<?> deleteWishlist(@PathVariable Long wishlistId) {
         wishlistService.deleteWishlist(wishlistId);
         return ResponseEntity.noContent().build();
+    }
+
+    @Secured(UserRole.Authority.USER)
+    @GetMapping
+    public ResponseEntity<WishlistPageResponse> findWishlist(@AuthenticationPrincipal Long userId, Pageable pageable) {
+        return ResponseEntity.ok(wishlistService.findWishlist(userId, pageable));
     }
 }

--- a/src/main/java/com/ticketland/ticketland/wishlist/domain/Wishlist.java
+++ b/src/main/java/com/ticketland/ticketland/wishlist/domain/Wishlist.java
@@ -12,9 +12,13 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
+@SQLDelete(sql = "UPDATE wishlist SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_Deleted = 0")
 public class Wishlist extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/ticketland/ticketland/wishlist/domain/Wishlist.java
+++ b/src/main/java/com/ticketland/ticketland/wishlist/domain/Wishlist.java
@@ -1,6 +1,8 @@
-package com.ticketland.ticketland.show.domain;
+package com.ticketland.ticketland.wishlist.domain;
 
 import com.ticketland.ticketland.global.domain.BaseTimeEntity;
+import com.ticketland.ticketland.show.domain.Show;
+import com.ticketland.ticketland.user.domain.User;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -8,33 +10,30 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@Table(name = "shows")
-public class Show extends BaseTimeEntity {
+public class Wishlist extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "genre_id")
-    private Genre genre;
+    @JoinColumn(name = "user_id")
+    private User user;
 
-    private String performer;
-    private String title;
-    private String descriptionImage;
-    private LocalDateTime ticketingTime;
-    private LocalDateTime startTime;
-    private Integer duration; // 공연시간 (분)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "show_id")
+    private Show show;
     private boolean isDeleted = false;
-
-    public String getGenreName() {
-        return genre.getGenreName();
+    @Builder
+    public Wishlist(User user, Show show) {
+        this.user = user;
+        this.show = show;
     }
+
+    protected Wishlist() {}
 }

--- a/src/main/java/com/ticketland/ticketland/wishlist/dto/WishlistPageResponse.java
+++ b/src/main/java/com/ticketland/ticketland/wishlist/dto/WishlistPageResponse.java
@@ -1,0 +1,35 @@
+package com.ticketland.ticketland.wishlist.dto;
+
+import com.ticketland.ticketland.wishlist.domain.Wishlist;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class WishlistPageResponse {
+
+    private Integer currentPage;
+    private Integer lastPage;
+    private Integer pageSize;
+    private List<WishlistResponse> content;
+
+    public static WishlistPageResponse from(Page<Wishlist> wishlistPage) {
+        List<WishlistResponse> content = wishlistPage.getContent().stream()
+                .map(WishlistResponse::from)
+                .toList();
+
+        return builder()
+                .currentPage(wishlistPage.getNumber())
+                .lastPage(wishlistPage.getTotalPages() - 1)
+                .pageSize(wishlistPage.getSize())
+                .content(content)
+                .build();
+    }
+}

--- a/src/main/java/com/ticketland/ticketland/wishlist/dto/WishlistResponse.java
+++ b/src/main/java/com/ticketland/ticketland/wishlist/dto/WishlistResponse.java
@@ -15,15 +15,12 @@ import lombok.NoArgsConstructor;
 @Builder
 public class WishlistResponse {
     private Long wishlistId;
-    private Long userId;
     private ShowSingleResponse show;
 
     public static WishlistResponse from(Wishlist wishlist) {
         Show findShow = wishlist.getShow();
-        User user = wishlist.getUser();
 
         return builder()
-                .userId(user.getId())
                 .wishlistId(wishlist.getId())
                 .show(ShowSingleResponse.from(findShow))
                 .build();

--- a/src/main/java/com/ticketland/ticketland/wishlist/dto/WishlistResponse.java
+++ b/src/main/java/com/ticketland/ticketland/wishlist/dto/WishlistResponse.java
@@ -1,0 +1,31 @@
+package com.ticketland.ticketland.wishlist.dto;
+
+import com.ticketland.ticketland.show.domain.Show;
+import com.ticketland.ticketland.show.dto.ShowSingleResponse;
+import com.ticketland.ticketland.user.domain.User;
+import com.ticketland.ticketland.wishlist.domain.Wishlist;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class WishlistResponse {
+    private Long wishlistId;
+    private Long userId;
+    private ShowSingleResponse show;
+
+    public static WishlistResponse from(Wishlist wishlist) {
+        Show findShow = wishlist.getShow();
+        User user = wishlist.getUser();
+
+        return builder()
+                .userId(user.getId())
+                .wishlistId(wishlist.getId())
+                .show(ShowSingleResponse.from(findShow))
+                .build();
+    }
+}

--- a/src/main/java/com/ticketland/ticketland/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/com/ticketland/ticketland/wishlist/repository/WishlistRepository.java
@@ -1,0 +1,8 @@
+package com.ticketland.ticketland.wishlist.repository;
+
+import com.ticketland.ticketland.wishlist.domain.Wishlist;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
+
+}

--- a/src/main/java/com/ticketland/ticketland/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/com/ticketland/ticketland/wishlist/repository/WishlistRepository.java
@@ -1,8 +1,8 @@
 package com.ticketland.ticketland.wishlist.repository;
 
 import com.ticketland.ticketland.wishlist.domain.Wishlist;
+import com.ticketland.ticketland.wishlist.repository.querydsl.WishlistRepositoryQuerydsl;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
-
+public interface WishlistRepository extends JpaRepository<Wishlist, Long>, WishlistRepositoryQuerydsl {
 }

--- a/src/main/java/com/ticketland/ticketland/wishlist/repository/querydsl/WishlistRepositoryQuerydsl.java
+++ b/src/main/java/com/ticketland/ticketland/wishlist/repository/querydsl/WishlistRepositoryQuerydsl.java
@@ -1,0 +1,9 @@
+package com.ticketland.ticketland.wishlist.repository.querydsl;
+
+import com.ticketland.ticketland.wishlist.domain.Wishlist;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface WishlistRepositoryQuerydsl {
+    Page<Wishlist> findWishlistByUserId(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/ticketland/ticketland/wishlist/repository/querydsl/WishlistRepositoryQuerydslImpl.java
+++ b/src/main/java/com/ticketland/ticketland/wishlist/repository/querydsl/WishlistRepositoryQuerydslImpl.java
@@ -1,0 +1,36 @@
+package com.ticketland.ticketland.wishlist.repository.querydsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ticketland.ticketland.wishlist.domain.Wishlist;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static com.ticketland.ticketland.wishlist.domain.QWishlist.wishlist;
+
+@RequiredArgsConstructor
+public class WishlistRepositoryQuerydslImpl implements WishlistRepositoryQuerydsl{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Wishlist> findWishlistByUserId(Long userId, Pageable pageable) {
+        List<Wishlist> content = queryFactory.selectFrom(wishlist)
+                .leftJoin(wishlist.show).fetchJoin() // user 관련해서는 필요 없으므로 공연관련해서만 fetchJoin
+                .leftJoin(wishlist.show.genre).fetchJoin()
+                .where(wishlist.user.id.eq(userId).and(wishlist.isDeleted.eq(false)))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory.select(wishlist.count()).from(wishlist)
+                .where(wishlist.user.id.eq(userId)
+                        .and(wishlist.isDeleted.eq(false)))
+                .fetchFirst();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+}

--- a/src/main/java/com/ticketland/ticketland/wishlist/service/WishlistService.java
+++ b/src/main/java/com/ticketland/ticketland/wishlist/service/WishlistService.java
@@ -7,9 +7,12 @@ import com.ticketland.ticketland.show.repository.ShowRepository;
 import com.ticketland.ticketland.user.domain.User;
 import com.ticketland.ticketland.user.repository.UserRepository;
 import com.ticketland.ticketland.wishlist.domain.Wishlist;
+import com.ticketland.ticketland.wishlist.dto.WishlistPageResponse;
 import com.ticketland.ticketland.wishlist.dto.WishlistResponse;
 import com.ticketland.ticketland.wishlist.repository.WishlistRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -36,5 +39,10 @@ public class WishlistService {
     public void deleteWishlist(Long wishlistId) {
         Wishlist wishlist = wishlistRepository.findById(wishlistId).orElseThrow(() -> new NotFoundException("위시리스트"));
         wishlistRepository.delete(wishlist);
+    }
+
+    public WishlistPageResponse findWishlist(Long userId, Pageable pageable) {
+        Page<Wishlist> wishlistPage = wishlistRepository.findWishlistByUserId(userId, pageable);
+        return WishlistPageResponse.from(wishlistPage);
     }
 }

--- a/src/main/java/com/ticketland/ticketland/wishlist/service/WishlistService.java
+++ b/src/main/java/com/ticketland/ticketland/wishlist/service/WishlistService.java
@@ -32,4 +32,9 @@ public class WishlistService {
         wishlistRepository.save(wishlist);
         return WishlistResponse.from(wishlist);
     }
+
+    public void deleteWishlist(Long wishlistId) {
+        Wishlist wishlist = wishlistRepository.findById(wishlistId).orElseThrow(() -> new NotFoundException("위시리스트"));
+        wishlistRepository.delete(wishlist);
+    }
 }

--- a/src/main/java/com/ticketland/ticketland/wishlist/service/WishlistService.java
+++ b/src/main/java/com/ticketland/ticketland/wishlist/service/WishlistService.java
@@ -1,0 +1,35 @@
+package com.ticketland.ticketland.wishlist.service;
+
+
+import com.ticketland.ticketland.global.exception.NotFoundException;
+import com.ticketland.ticketland.show.domain.Show;
+import com.ticketland.ticketland.show.repository.ShowRepository;
+import com.ticketland.ticketland.user.domain.User;
+import com.ticketland.ticketland.user.repository.UserRepository;
+import com.ticketland.ticketland.wishlist.domain.Wishlist;
+import com.ticketland.ticketland.wishlist.dto.WishlistResponse;
+import com.ticketland.ticketland.wishlist.repository.WishlistRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class WishlistService {
+
+    private final WishlistRepository wishlistRepository;
+    private final UserRepository userRepository;
+    private final ShowRepository showRepository;
+
+    public WishlistResponse createWishlist(Long userId, Long showId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundException("회원"));
+        Show show = showRepository.findById(showId).orElseThrow(() -> new NotFoundException("공연"));
+
+        Wishlist wishlist = Wishlist.builder()
+                .user(user)
+                .show(show)
+                .build();
+
+        wishlistRepository.save(wishlist);
+        return WishlistResponse.from(wishlist);
+    }
+}


### PR DESCRIPTION
## 연관 이슈
close: #9 

## 작업 내용

- [x] 장르 도메인 추가하기 (공연 도메인과 연결)
- [x] 검색기능 추가하기 (공연을 장르별로 조회할 수 있다)
- [x] 위시리스트 도메인 추가하기 (USER와 공연과 연결)
- [x] 위시리스트 관련 기능 추가하기
    - [x] 유저는 위시리스트에 공연을 추가할 수 있다.
    - [x] 유저는 위시리스트에 공연을 삭제할 수 있다.
    - [x] 유저는 본인의 위시리스트를 조회할 수 있다. (페이징 방식 조회)

## 기타